### PR TITLE
fix: resolve __dirname error in ES modules for production deployment

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -5,8 +5,13 @@ import messageRoutes from './routes/message.routes.js';
 import { ENV } from './lib/env.js';
 import { connectDB } from './lib/db.js';
 import path from 'path';
+import { fileURLToPath } from 'url';
 
 const app = express();
+
+// ES module equivalent of __dirname
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const PORT = ENV.PORT || 3000;
 app.use(express.json());


### PR DESCRIPTION
- Add fileURLToPath import from url module
- Create ES module equivalent of __dirname using import.meta.url
- Fix static file serving for frontend in production environment
- Resolves deployment error: ReferenceError: __dirname is not defined in ES module scope

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of serving static assets in production by correcting path resolution, preventing occasional missing files or incorrect routes.
  * No changes to public APIs or user-facing configuration required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->